### PR TITLE
Update explainer/scoring model to gpt-4-turbo

### DIFF
--- a/neuron_explainer/activation_server/explainer_routes.py
+++ b/neuron_explainer/activation_server/explainer_routes.py
@@ -64,7 +64,7 @@ class NeuronExplainAndScoreMethodId(BaseMethodId):
 
 _NEURON_EXPLAINER_REGISTRY: dict[NeuronExplainAndScoreMethodId, NeuronExplainer] = {
     NeuronExplainAndScoreMethodId.BASELINE: TokenActivationPairExplainer(
-        model_name="gpt-4",
+        model_name="gpt-4-turbo",
         cache=True,
         prompt_format=PromptFormat.CHAT_MESSAGES,
     ),
@@ -82,12 +82,12 @@ _ATTENTION_EXPLAINER_REGISTRY: dict[
 ] = {
     AttentionExplainAndScoreMethodId.BASELINE: (
         AttentionHeadExplainer(
-            model_name="gpt-4",
+            model_name="gpt-4-turbo",
             prompt_format=PromptFormat.CHAT_MESSAGES,
             repeat_strongly_attending_pairs=True,
         ),
         AttentionHeadOneAtATimeScorer(
-            model_name="gpt-4",
+            model_name="gpt-4-turbo",
             prompt_format=PromptFormat.CHAT_MESSAGES,
         ),
     )
@@ -125,7 +125,7 @@ def define_explainer_routes(
     attention_head_method_id: AttentionExplainAndScoreMethodId,
 ) -> None:
     simulation_client = ApiClient(
-        model_name="gpt-4-0125-preview",  # turbo model
+        model_name="gpt-4-turbo",  # turbo model
         max_concurrent=5,
         cache=True,
     )

--- a/neuron_explainer/explanations/attention_head_scoring.py
+++ b/neuron_explainer/explanations/attention_head_scoring.py
@@ -243,7 +243,7 @@ Sequence:\n{format_attention_head_token_pair_string(tokens, simulation_coords)}"
 if __name__ == "__main__":
     # Example usage
     async def main() -> None:
-        scorer = AttentionHeadOneAtATimeScorer("gpt-4")
+        scorer = AttentionHeadOneAtATimeScorer("gpt-4-turbo")
         explanation = "attends from tokens to the first token in the sequence"
         attention_head = load_neuron(
             "https://openaipublic.blob.core.windows.net/neuron-explainer/gpt2_small/attn_write_norm/collated_activations_by_token_pair",

--- a/neuron_explainer/explanations/simulator.py
+++ b/neuron_explainer/explanations/simulator.py
@@ -842,7 +842,7 @@ if __name__ == "__main__":
         "21",
         "2932",
     )
-    client = ApiClient(model_name="gpt-4", max_concurrent=5)
+    client = ApiClient(model_name="gpt-4-turbo", max_concurrent=5)
 
     simulator = LogprobFreeExplanationTokenSimulator(
         client=client, explanation="Canada or things related to Canada"

--- a/neuron_explainer/explanations/test_explainer.py
+++ b/neuron_explainer/explanations/test_explainer.py
@@ -49,7 +49,7 @@ f	0
 Explanation of neuron 2 behavior:<|endofprompt|> this neuron activates for"""
 
     explainer = TokenActivationPairExplainer(
-        model_name="gpt-4",
+        model_name="gpt-4-turbo",
         prompt_format=PromptFormat.INSTRUCTION_FOLLOWING,
         few_shot_example_set=FewShotExampleSet.TEST,
     )
@@ -115,7 +115,7 @@ Explanation of neuron 2 behavior: this neuron activates for""",
     ]
 
     explainer = TokenActivationPairExplainer(
-        model_name="gpt-4",
+        model_name="gpt-4-turbo",
         prompt_format=PromptFormat.CHAT_MESSAGES,
         few_shot_example_set=FewShotExampleSet.TEST,
     )


### PR DESCRIPTION
This PR updates the model names in `neuron_explainer` to use the recently updated version of GPT-4, `gpt-4-turbo` (which currently points to `gpt-4-turbo-2024-04-09`)

The reasons for this change are:

1. **Better explanations/scoring:** I noticed slightly improved MLP explanation scoring when using the new `gpt-4-turbo-2024-04-09` model vs. the currently used `gpt-4` (currently points to `gpt-4-0613`) and `gpt-4-0125-preview` models. Specifically, I observed higher confidence scores for accurate explanations and fewer instances of high scores for poor explanations.

> Here is a quick model comparison test with `gpt-2-small` using the `mlp_neuron` dataset at 1:1

![TDB-model-score-test-1](https://github.com/openai/transformer-debugger/assets/58921460/59dc4686-ce60-4ce4-99df-f9bf9d913b89)

2. **More cost-effective:** The `gpt-4-turbo-2024-04-09` model is cheaper than the currently used `gpt-4-0613` model (1/3 the input cost and 1/2 the output cost according to https://openai.com/pricing).

If this proposed model change would disrupt any TDB use cases, the following alternatives may be worth considering instead:

- Allow users to set or override the default model via environment variable, e.g. `EXPLAINER_MODEL` or similar. 

- Display the active explainer/scoring model name in the TDB UI and/or add "model name" attribution for scored explanations in the local cached explanation directory.
  
- Use the version-specific model names (`gpt-4-turbo-2024-04-09` instead of `gpt-4-turbo`) to prevent potential inconsistencies due to continuous model upgrades.

Open to all feedback and suggestions, thank you.

---

Model info: https://platform.openai.com/docs/models/continuous-model-upgrades

- `gpt-4-turbo` currently points to `gpt-4-turbo-2024-04-09`

- `gpt-4` currently points to `gpt-4-0613`