### PR TITLE
Pin pre-commit hook revisions to immutable commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.9
+    rev: 7bcc70ca475b87e0fdee2511300c74b25babe0b3
     hooks:
       - id: ruff
         args: [--fix, --unsafe-fixes, --fix-only, --exit-non-zero-on-fix]
         files: neuron_explainer
 
   - repo: https://github.com/hauntsaninja/black-pre-commit-mirror
-    rev: 23.10.0
+    rev: 91867dbada8a528dcc51a369d95a9d11a81a26a8
     hooks:
       - id: black
         args: [--line-length=100, --exclude="", --workers=6]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: e44834b7b294701f596c9118d6c370f86671a50d
     hooks:
       - id: isort
         args: [--line-length=100, --profile=black, --settings-path=.isort.cfg]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 7bcc70ca475b87e0fdee2511300c74b25babe0b3
+    rev: 7bcc70ca475b87e0fdee2511300c74b25babe0b3  # v0.1.9
     hooks:
       - id: ruff
         args: [--fix, --unsafe-fixes, --fix-only, --exit-non-zero-on-fix]
         files: neuron_explainer
 
   - repo: https://github.com/hauntsaninja/black-pre-commit-mirror
-    rev: 91867dbada8a528dcc51a369d95a9d11a81a26a8
+    rev: 91867dbada8a528dcc51a369d95a9d11a81a26a8  # 23.10.0
     hooks:
       - id: black
         args: [--line-length=100, --exclude="", --workers=6]
 
   - repo: https://github.com/pycqa/isort
-    rev: e44834b7b294701f596c9118d6c370f86671a50d
+    rev: e44834b7b294701f596c9118d6c370f86671a50d  # 5.12.0
     hooks:
       - id: isort
         args: [--line-length=100, --profile=black, --settings-path=.isort.cfg]


### PR DESCRIPTION
## What's changing
Replace non-commit `rev:` values in `.pre-commit-config.yaml` with the exact commit those refs resolve to today.

## Why
Tags and branch names can be retargeted upstream; pinning to immutable commits keeps the selected code the same over time.
